### PR TITLE
remove django-tastypie because it's a nearly dead project

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ _For a complete listing of all available packages, see [Django Packages](https:/
 - [drf-yasg](https://github.com/axnsan12/drf-yasg) - Automated generation of real Swagger/OpenAPI 2.0 schemas from Django REST Framework code.
 - [graphene-django](https://github.com/graphql-python/graphene-django) - GraphQL for Django.
 - [django-ninja](https://django-ninja.rest-framework.com/) - Django Ninja - Fast Django REST framework based on type annotations.
-- [django-tastypie](https://github.com/django-tastypie/django-tastypie) - Creating delicious APIs for Django apps since 2010.
 <!--lint enable double-link-->
 
 ### Async


### PR DESCRIPTION
Hello.
Long time Tastypie user here. Despite the project not being fully abandoned, it has not seen any significant update/feature in almost 10 years, when the original developer, Daniel Lindsley did a burn out and left the project. It has had the 0.14 version number for almost 10 years.

Meanwhile django-rest-framework has grown tremendously, whereas the two where equivalent 10 years ago, and is the de facto standard for making django rest APIs. I think tastypie should be removed because it could lead people to chose tastypie, and that would greatly arm their project.

Cheers